### PR TITLE
Handle empty description fields

### DIFF
--- a/src/main/scala/FbEvents.scala
+++ b/src/main/scala/FbEvents.scala
@@ -5,7 +5,7 @@ import spray.json._
 import scalaj.http._
 
 object FbEvents {
-  case class FbEvent(id: String, name: String, description: String, startTime: ZonedDateTime, endTime: Option[ZonedDateTime]);
+  case class FbEvent(id: String, name: String, description: Option[String], startTime: ZonedDateTime, endTime: Option[ZonedDateTime]);
   case class Response(data: List[FbEvent]);
 }
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -12,13 +12,16 @@ import icalendar.ical.Writer._
 trait Main extends FbEvents {
   implicit def liftOption[T](value: T): Option[T] = Some(value)
 
-  def convert(event: FbEvents.FbEvent): Event = Event(
-    uid = Uid(event.id),
-    dtstart = event.startTime,
-    summary = Summary(event.name),
-    description = Description(event.description),
-    url = Url(s"https://www.facebook.com/events/${event.id}/")
-  )
+  def convert(event: FbEvents.FbEvent): Event = {
+    val description: String = event.description.getOrElse("");
+    Event(
+      uid = Uid(event.id),
+      dtstart = event.startTime,
+      summary = Summary(event.name),
+      description = Description(description),
+      url = Url(s"https://www.facebook.com/events/${event.id}/")
+    )
+  }
 
   def getICalendar(token: String, pageId: String): String = {
     asIcal(Calendar(


### PR DESCRIPTION
Looks like description can be left blank, and must come back as 'null' in the JSON.  Here's a fix: